### PR TITLE
feat: navigation & integration (#8)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,10 @@
       "workspaces": [
         "packages/frontend",
         "packages/backend"
-      ]
+      ],
+      "devDependencies": {
+        "concurrently": "^9.1.0"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -1888,6 +1891,36 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/chownr": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
@@ -1947,6 +1980,31 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
+    },
+    "node_modules/concurrently": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
+      "integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "4.1.2",
+        "rxjs": "7.8.2",
+        "shell-quote": "1.8.3",
+        "supports-color": "8.1.1",
+        "tree-kill": "1.2.2",
+        "yargs": "17.7.2"
+      },
+      "bin": {
+        "conc": "dist/bin/concurrently.js",
+        "concurrently": "dist/bin/concurrently.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -2827,6 +2885,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/has-symbols": {
@@ -3877,6 +3945,16 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -3981,6 +4059,19 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/shell-quote": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/side-channel": {
       "version": "1.1.0",
@@ -4221,6 +4312,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/tar-fs": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
@@ -4317,6 +4424,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
       }
     },
     "node_modules/tslib": {

--- a/package.json
+++ b/package.json
@@ -7,8 +7,11 @@
     "packages/backend"
   ],
   "scripts": {
-    "dev": "npm run dev --workspace=packages/backend & npm run dev --workspace=packages/frontend",
+    "dev": "concurrently -n backend,frontend -c blue,green \"npm run dev --workspace=packages/backend\" \"npm run dev --workspace=packages/frontend\"",
     "build": "npm run build --workspace=packages/frontend",
     "start": "npm run start --workspace=packages/backend"
+  },
+  "devDependencies": {
+    "concurrently": "^9.1.0"
   }
 }

--- a/packages/frontend/src/App.jsx
+++ b/packages/frontend/src/App.jsx
@@ -2,6 +2,7 @@ import { BrowserRouter, Routes, Route, Link, useLocation } from 'react-router-do
 import Dashboard from './pages/Dashboard';
 import SchedulerPage from './pages/SchedulerPage.jsx';
 import TemplateBuilder from './pages/TemplateBuilder';
+import TemplateSchedulePage from './pages/TemplateSchedulePage.jsx';
 
 function NavBar() {
   const location = useLocation();
@@ -63,6 +64,7 @@ function App() {
         <Route path="/schedules" element={<SchedulerPage />} />
         <Route path="/templates/new" element={<TemplateBuilder />} />
         <Route path="/templates/:id" element={<TemplateBuilder />} />
+        <Route path="/templates/:id/schedule" element={<TemplateSchedulePage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/packages/frontend/src/api.js
+++ b/packages/frontend/src/api.js
@@ -1,4 +1,4 @@
-const API_BASE = '/api';
+const API_BASE = import.meta.env.VITE_API_BASE_URL || '/api';
 
 async function request(path, options = {}) {
   const res = await fetch(`${API_BASE}${path}`, {

--- a/packages/frontend/src/pages/Dashboard.css
+++ b/packages/frontend/src/pages/Dashboard.css
@@ -154,6 +154,15 @@
   color: #374151;
 }
 
+.btn-action.schedule {
+  color: #7c3aed;
+  border-color: #c4b5fd;
+}
+
+.btn-action.schedule:hover {
+  background: #f5f3ff;
+}
+
 .btn-action.delete {
   color: #dc2626;
   border-color: #fca5a5;

--- a/packages/frontend/src/pages/Dashboard.jsx
+++ b/packages/frontend/src/pages/Dashboard.jsx
@@ -1,6 +1,12 @@
 import { useState, useEffect, useCallback } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
+import {
+  fetchTemplates as apiFetchTemplates,
+  deleteTemplate as apiDeleteTemplate,
+} from '../api.js';
 import './Dashboard.css';
+
+const API_BASE = import.meta.env.VITE_API_BASE_URL || '/api';
 
 function formatSchedule(schedule) {
   if (!schedule) return null;
@@ -34,11 +40,9 @@ export default function Dashboard() {
   const [runningIds, setRunningIds] = useState(new Set());
   const navigate = useNavigate();
 
-  const fetchTemplates = useCallback(async () => {
+  const loadTemplates = useCallback(async () => {
     try {
-      const res = await fetch('/api/templates');
-      if (!res.ok) throw new Error('Failed to fetch templates');
-      const data = await res.json();
+      const data = await apiFetchTemplates();
       setTemplates(data);
       setError(null);
     } catch (err) {
@@ -49,15 +53,15 @@ export default function Dashboard() {
   }, []);
 
   useEffect(() => {
-    fetchTemplates();
-  }, [fetchTemplates]);
+    loadTemplates();
+  }, [loadTemplates]);
 
   const handleRunNow = async (templateId) => {
     setRunningIds(prev => new Set(prev).add(templateId));
     try {
-      const res = await fetch(`/api/reports/${templateId}/run`, { method: 'POST' });
+      const res = await fetch(`${API_BASE}/reports/${templateId}/run`, { method: 'POST' });
       if (!res.ok) throw new Error('Run failed');
-      await fetchTemplates();
+      await loadTemplates();
     } catch (err) {
       console.error('Run failed:', err);
     } finally {
@@ -72,10 +76,9 @@ export default function Dashboard() {
   const handleDelete = async () => {
     if (!deleteTarget) return;
     try {
-      const res = await fetch(`/api/templates/${deleteTarget.id}`, { method: 'DELETE' });
-      if (!res.ok) throw new Error('Delete failed');
+      await apiDeleteTemplate(deleteTarget.id);
       setDeleteTarget(null);
-      await fetchTemplates();
+      await loadTemplates();
     } catch (err) {
       console.error('Delete failed:', err);
     }
@@ -148,6 +151,12 @@ export default function Dashboard() {
                     onClick={() => navigate(`/templates/${t.id}`)}
                   >
                     Edit
+                  </button>
+                  <button
+                    className="btn-action schedule"
+                    onClick={() => navigate(`/templates/${t.id}/schedule`)}
+                  >
+                    Schedule
                   </button>
                   <button
                     className="btn-action delete"

--- a/packages/frontend/src/pages/TemplateSchedulePage.jsx
+++ b/packages/frontend/src/pages/TemplateSchedulePage.jsx
@@ -1,0 +1,288 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useParams, useNavigate, Link } from 'react-router-dom';
+import ScheduleForm from '../components/ScheduleForm.jsx';
+import RunHistory from '../components/RunHistory.jsx';
+import {
+  fetchTemplate,
+  fetchSchedules,
+  createSchedule,
+  updateSchedule,
+  deleteSchedule,
+  fetchRunHistory,
+} from '../api.js';
+
+export default function TemplateSchedulePage() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const [template, setTemplate] = useState(null);
+  const [schedule, setSchedule] = useState(null);
+  const [historyData, setHistoryData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [editing, setEditing] = useState(false);
+
+  const loadData = useCallback(async () => {
+    try {
+      setError('');
+      const [tmpl, allSchedules] = await Promise.all([
+        fetchTemplate(id),
+        fetchSchedules(),
+      ]);
+      setTemplate(tmpl);
+      const match = allSchedules.find(s => s.templateId === id);
+      setSchedule(match || null);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }, [id]);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  async function handleCreate(data) {
+    try {
+      setError('');
+      await createSchedule({ ...data, templateId: id });
+      setEditing(false);
+      await loadData();
+    } catch (err) {
+      setError(err.message);
+    }
+  }
+
+  async function handleUpdate(data) {
+    try {
+      setError('');
+      await updateSchedule(schedule.id, data);
+      setEditing(false);
+      await loadData();
+    } catch (err) {
+      setError(err.message);
+    }
+  }
+
+  async function handleDelete() {
+    if (!window.confirm('Are you sure you want to remove this schedule?')) return;
+    try {
+      setError('');
+      await deleteSchedule(schedule.id);
+      setSchedule(null);
+      setEditing(false);
+      await loadData();
+    } catch (err) {
+      setError(err.message);
+    }
+  }
+
+  async function handleViewHistory() {
+    if (!schedule) return;
+    try {
+      setError('');
+      const runs = await fetchRunHistory(schedule.id);
+      setHistoryData({ runs, scheduleName: template.name });
+    } catch (err) {
+      setError(err.message);
+    }
+  }
+
+  if (loading) {
+    return <div style={styles.loading}>Loading schedule configuration...</div>;
+  }
+
+  if (!template) {
+    return (
+      <div style={styles.container}>
+        <div style={styles.error}>Template not found.</div>
+        <Link to="/" style={styles.backLink}>Back to Dashboard</Link>
+      </div>
+    );
+  }
+
+  const fmtSchedule = schedule
+    ? `${schedule.frequency.charAt(0).toUpperCase() + schedule.frequency.slice(1)} at ${schedule.time}`
+    : null;
+
+  return (
+    <div style={styles.container}>
+      <div style={styles.breadcrumb}>
+        <Link to="/" style={styles.backLink}>Dashboard</Link>
+        <span style={styles.sep}>/</span>
+        <Link to={`/templates/${id}`} style={styles.backLink}>{template.name}</Link>
+        <span style={styles.sep}>/</span>
+        <span>Schedule</span>
+      </div>
+
+      <h2 style={styles.title}>Schedule: {template.name}</h2>
+
+      {error && <div style={styles.error}>{error}</div>}
+
+      {!schedule && !editing && (
+        <div style={styles.emptyState}>
+          <p>No schedule configured for this template.</p>
+          <button onClick={() => setEditing(true)} style={styles.primaryBtn}>
+            + Create Schedule
+          </button>
+        </div>
+      )}
+
+      {!schedule && editing && (
+        <ScheduleForm
+          templates={[{ id, name: template.name, hasSchedule: false }]}
+          onSubmit={handleCreate}
+          onCancel={() => setEditing(false)}
+        />
+      )}
+
+      {schedule && !editing && (
+        <div style={styles.scheduleCard}>
+          <div style={styles.scheduleInfo}>
+            <div style={styles.scheduleLabel}>Current Schedule</div>
+            <div style={styles.scheduleDetail}>{fmtSchedule}</div>
+          </div>
+          <div style={styles.scheduleActions}>
+            <button onClick={() => setEditing(true)} style={styles.editBtn}>Edit</button>
+            <button onClick={handleViewHistory} style={styles.historyBtn}>View History</button>
+            <button onClick={handleDelete} style={styles.deleteBtn}>Remove</button>
+          </div>
+        </div>
+      )}
+
+      {schedule && editing && (
+        <ScheduleForm
+          templates={[{ id, name: template.name, hasSchedule: true }]}
+          schedule={schedule}
+          onSubmit={handleUpdate}
+          onCancel={() => setEditing(false)}
+        />
+      )}
+
+      {historyData && (
+        <RunHistory
+          runs={historyData.runs}
+          scheduleName={historyData.scheduleName}
+          onClose={() => setHistoryData(null)}
+        />
+      )}
+    </div>
+  );
+}
+
+const styles = {
+  container: {
+    maxWidth: '700px',
+    margin: '0 auto',
+    padding: '1.5rem',
+  },
+  breadcrumb: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '0.5rem',
+    fontSize: '0.875rem',
+    color: '#6b7280',
+    marginBottom: '1rem',
+  },
+  backLink: {
+    color: '#2563eb',
+    textDecoration: 'none',
+  },
+  sep: {
+    color: '#9ca3af',
+  },
+  title: {
+    margin: '0 0 1.5rem 0',
+    fontSize: '1.5rem',
+    color: '#111827',
+  },
+  error: {
+    background: '#f8d7da',
+    color: '#842029',
+    padding: '0.75rem 1rem',
+    borderRadius: '4px',
+    marginBottom: '1rem',
+    fontSize: '0.875rem',
+  },
+  loading: {
+    textAlign: 'center',
+    padding: '2rem',
+    color: '#666',
+  },
+  emptyState: {
+    textAlign: 'center',
+    padding: '2rem',
+    background: '#f9fafb',
+    borderRadius: '8px',
+    border: '1px dashed #d1d5db',
+    color: '#6b7280',
+  },
+  primaryBtn: {
+    marginTop: '0.75rem',
+    padding: '0.5rem 1rem',
+    background: '#198754',
+    color: '#fff',
+    border: 'none',
+    borderRadius: '4px',
+    cursor: 'pointer',
+    fontSize: '0.875rem',
+    fontWeight: '600',
+  },
+  scheduleCard: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    padding: '1rem 1.25rem',
+    background: '#f8f9fa',
+    border: '1px solid #dee2e6',
+    borderRadius: '8px',
+    marginBottom: '1rem',
+  },
+  scheduleInfo: {},
+  scheduleLabel: {
+    fontSize: '0.75rem',
+    fontWeight: '600',
+    textTransform: 'uppercase',
+    color: '#6b7280',
+    marginBottom: '0.25rem',
+  },
+  scheduleDetail: {
+    fontSize: '1rem',
+    fontWeight: '500',
+    color: '#111827',
+  },
+  scheduleActions: {
+    display: 'flex',
+    gap: '0.5rem',
+  },
+  editBtn: {
+    padding: '0.375rem 0.75rem',
+    background: '#0d6efd',
+    color: '#fff',
+    border: 'none',
+    borderRadius: '4px',
+    cursor: 'pointer',
+    fontSize: '0.8rem',
+    fontWeight: '600',
+  },
+  historyBtn: {
+    padding: '0.375rem 0.75rem',
+    background: '#6c757d',
+    color: '#fff',
+    border: 'none',
+    borderRadius: '4px',
+    cursor: 'pointer',
+    fontSize: '0.8rem',
+    fontWeight: '600',
+  },
+  deleteBtn: {
+    padding: '0.375rem 0.75rem',
+    background: '#dc3545',
+    color: '#fff',
+    border: 'none',
+    borderRadius: '4px',
+    cursor: 'pointer',
+    fontSize: '0.8rem',
+    fontWeight: '600',
+  },
+};


### PR DESCRIPTION
## Summary

- **8.1** Added `/templates/:id/schedule` route with a dedicated `TemplateSchedulePage` component for per-template schedule configuration (routes `/`, `/templates/new`, `/templates/:id` were already in place)
- **8.2** Top-level navigation bar with Dashboard, Schedules, and New Template links was already implemented; added a "Schedule" action button on dashboard template cards linking to `/templates/:id/schedule`
- **8.3** Made frontend API base URL configurable via `VITE_API_BASE_URL` environment variable (defaults to `/api`); updated Dashboard to use the centralized `api.js` wrapper instead of direct `fetch` calls
- **8.4** CORS middleware (`app.use(cors())`) was already in place on the Express backend
- **8.5** Replaced shell `&` background process with `concurrently` for the `dev` script, providing labeled output and proper process cleanup; `build` and `start` scripts were already configured

Closes #8

## Test plan

- [ ] Verify `npm run dev` starts both frontend and backend with labeled output
- [ ] Navigate to `/` and confirm Dashboard loads with template list
- [ ] Click "New Template" in the nav bar and verify `/templates/new` route
- [ ] Click "Edit" on a template card and verify `/templates/:id` route
- [ ] Click "Schedule" on a template card and verify `/templates/:id/schedule` loads with schedule config form
- [ ] Create/edit/delete a schedule from the template schedule page
- [ ] Verify `npm run build` completes without errors
- [ ] Verify `npm run start` starts the backend server
- [ ] Set `VITE_API_BASE_URL` env var and confirm API calls use the custom base URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)